### PR TITLE
More fast path fixes

### DIFF
--- a/src/Microsoft.TestPlatform.Common/Filtering/FastFilter.cs
+++ b/src/Microsoft.TestPlatform.Common/Filtering/FastFilter.cs
@@ -109,8 +109,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Filtering
             var propertyValue = propertyValueProvider(name);
             if (null != propertyValue)
             {
-                singleValue = propertyValue as string;
-                multiValues = singleValue == null ? propertyValue as string[] : null;
+                multiValues = propertyValue as string[];
+                singleValue = multiValues == null? propertyValue.ToString() : null;
                 return true;
             }
 


### PR DESCRIPTION
A smoke test was failing where Priority which was int could not be converted to a string and singleValue turned out to be null. Mimicked filterExpression.Evaluate.